### PR TITLE
Specify a specific hint path for MonoGame to avoid ambiguous references

### DIFF
--- a/DemoForWindows/DemoForWindows.csproj
+++ b/DemoForWindows/DemoForWindows.csproj
@@ -40,6 +40,26 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;WINDOWS</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;WINDOWS</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="WindowsGameRunner.cs" />
     <Compile Include="Program.cs" />

--- a/MonoVarmint.sln
+++ b/MonoVarmint.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Stuff", "Stuff", "{00DBFC4F-5E84-4386-A95E-C34E74C5C680}"
 	ProjectSection(SolutionItems) = preProject
@@ -38,36 +38,22 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Debug|x86.Build.0 = Debug|Any CPU
+		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Release|x86.ActiveCfg = Release|Any CPU
-		{CA303E85-5E76-47DF-B81E-85127FFD3010}.Release|x86.Build.0 = Release|Any CPU
-		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Debug|x86.ActiveCfg = Debug|x86
-		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Debug|x86.Build.0 = Debug|x86
+		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Release|Any CPU.ActiveCfg = Release|x86
-		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Release|x86.ActiveCfg = Release|x86
-		{FEE379EF-A613-451B-91BF-595B3FCD2448}.Release|x86.Build.0 = Release|x86
 		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Debug|x86.Build.0 = Debug|Any CPU
-		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Debug|x86.Deploy.0 = Debug|Any CPU
 		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Release|Any CPU.Build.0 = Release|Any CPU
 		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Release|x86.ActiveCfg = Release|Any CPU
-		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Release|x86.Build.0 = Release|Any CPU
-		{199B5BB6-E9D2-4EDE-8E37-617D03924201}.Release|x86.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/TestsForVarmintTools.csproj
+++ b/Tests/TestsForVarmintTools.csproj
@@ -44,7 +44,10 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="MonoGame.Framework, Version=3.6.0.1625, Culture=neutral, processorArchitecture=MSIL" />
+    <Reference Include="MonoGame.Framework, Version=3.5.1.1679, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Program Files (x86)\MonoGame\v3.0\Assemblies\Windows\MonoGame.Framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.XML" />


### PR DESCRIPTION
(Also removes stray x86 build configuration)