### PR TITLE
Fix render target inside render target bug

### DIFF
--- a/Demo.Shared/Layout/MainScreen.vwml
+++ b/Demo.Shared/Layout/MainScreen.vwml
@@ -30,7 +30,16 @@
       ForegroundColor="Yellow"
       Content="WOW!"
       VerticalContentAlignment="Center"
-      Rotate="{WowRotate}" />
+      Rotate="{WowRotate}" >
+      <Label
+        Size=".1,.1"
+        FontSize=".04"
+        Margin=".01,.01"
+        ForegroundColor="White"
+        Content="WOW!"
+        VerticalContentAlignment="Center"
+        Rotate="{WowRotate}"/>
+    </Label>
     <Slider Size=".8,.1" BackgroundColor="Red" Value="{MySliderValue}">
       <Slider.Track>
         <Label Content="|-------------------------|" Stretch="1,1"/> 

--- a/DemoForAndroid/DemoForAndroid.csproj
+++ b/DemoForAndroid/DemoForAndroid.csproj
@@ -34,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/DemoForWindows/DemoForWindows.csproj
+++ b/DemoForWindows/DemoForWindows.csproj
@@ -50,6 +50,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>

--- a/Tests/TestsForVarmintTools.csproj
+++ b/Tests/TestsForVarmintTools.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Widgets/GameController/GameControllerRendering.cs
+++ b/Widgets/GameController/GameControllerRendering.cs
@@ -596,7 +596,7 @@ namespace MonoVarmint.Widgets
         //--------------------------------------------------------------------------------------
         public void BeginClipping(Vector2 absolutePosition, Vector2 size)
         {
-            
+
             var position = absolutePosition - DrawOffset;
             var rawPosition = position * _backBufferWidth;
             var rawSize = size * _backBufferWidth;
@@ -659,7 +659,7 @@ namespace MonoVarmint.Widgets
                 origin,
                 scale,
                 effects,
-                _drawBuffers.Count);
+                _drawBuffers.Count / 16384.0f); // anything outside of [0..1] gets clipped away - support reasonable depth
             ReturnRenderTarget(drawBuffer.RenderBuffer);
             DrawOffset = drawBuffer.PreviousDrawOffset;
         }

--- a/Widgets/GameController/GameControllerRendering.cs
+++ b/Widgets/GameController/GameControllerRendering.cs
@@ -659,7 +659,7 @@ namespace MonoVarmint.Widgets
                 origin,
                 scale,
                 effects,
-                _drawBuffers.Count / 16384.0f); // anything outside of [0..1] gets clipped away - support reasonable depth
+                1f - (_drawBuffers.Count / 16384.0f)); // anything outside of [0..1] gets clipped away - support reasonable depth
             ReturnRenderTarget(drawBuffer.RenderBuffer);
             DrawOffset = drawBuffer.PreviousDrawOffset;
         }


### PR DESCRIPTION
I FIXED IT! Sure, this doesn't give us any custom shaders yet, but it does mean that rotation and clipping should be very easy now.

It actually was not render target limits at all - the culprit was simply the depth values we provided to SpriteBatch.Draw. Dividing the old depth value by 2^14 should supply all reasonable depths for most games.