### PR TITLE
Fix GameController to user premultiplied alpha for transparency

### DIFF
--- a/DemoForAndroid/DemoForAndroid.csproj
+++ b/DemoForAndroid/DemoForAndroid.csproj
@@ -19,7 +19,7 @@
     <AndroidSupportedAbis>armeabi-v7a%3bx86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions>.m4a</AndroidStoreUncompressedFileExtensions>
     <MandroidI18n />
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <MonoGamePlatform>Android</MonoGamePlatform>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>

--- a/Widgets/GameController/GameController.cs
+++ b/Widgets/GameController/GameController.cs
@@ -236,7 +236,7 @@ namespace MonoVarmint.Widgets
 
             //Debug.WriteLine("AAA---------------------- BEGIN ------------------------");
             //Debug.WriteLine("AAA_spriteBatch.Begin();");
-            _spriteBatch.Begin(blendState: BlendState.NonPremultiplied);
+            _spriteBatch.Begin();
             GraphicsDevice.Clear(GlobalBackgroundColor);
             BeginClipping(DrawOffset, ScreenSize);
             _visualTree.Prepare(_widgetSpace.StyleLibrary);

--- a/Widgets/GameController/GameControllerRendering.cs
+++ b/Widgets/GameController/GameControllerRendering.cs
@@ -557,7 +557,7 @@ namespace MonoVarmint.Widgets
             //Debug.WriteLine("AAAGraphicsDevice.SetRenderTarget(RenderBuffer" + newBuffer.RawSize + ");");
            GraphicsDevice.SetRenderTarget(newBuffer.RenderBuffer);
            // Debug.WriteLine("AAA_spriteBatch.Begin();");
-           _spriteBatch.Begin(blendState: BlendState.NonPremultiplied);
+           _spriteBatch.Begin();
             GraphicsDevice.Clear(new Color(0, 0, 0, 0));
             _drawBuffers.Push(newBuffer);
         }
@@ -582,7 +582,7 @@ namespace MonoVarmint.Widgets
                 GraphicsDevice.SetRenderTarget(null);
             }
             //Debug.WriteLine("AAA_spriteBatch.Begin();");
-            _spriteBatch.Begin(blendState: BlendState.NonPremultiplied);
+            _spriteBatch.Begin();
 
             SpriteEffects effects = SpriteEffects.None;
             if (flipHorizontal) effects |= SpriteEffects.FlipHorizontally;

--- a/Widgets/WidgetBase/VarmintWidget.cs
+++ b/Widgets/WidgetBase/VarmintWidget.cs
@@ -244,17 +244,17 @@ namespace MonoVarmint.Widgets
 
         public virtual Color RenderBackgroundColor
         {
-            get { return new Color(BackgroundColor, AbsoluteOpacity * BackgroundColor.A / 255);  }
+            get { return BackgroundColor * AbsoluteOpacity;  }
         }
 
         public virtual Color RenderForegroundColor
         {
-            get { return new Color(ForegroundColor, AbsoluteOpacity * ForegroundColor.A / 255); }
+            get { return ForegroundColor * AbsoluteOpacity; }
         }
 
         public virtual Color RenderGraphicColor
         {
-            get { return new Color(Color.White, AbsoluteOpacity); }
+            get { return Color.White * AbsoluteOpacity; }
         }
 
         //--------------------------------------------------------------------------------------


### PR DESCRIPTION
Attempting to use non-premultiplied alpha was causing unpredictable graphical errors, so we changed to use the default of premultiplied alpha.