### PR TITLE
Cause VarmintAnimation to animate the last frame before concluding

### DIFF
--- a/DemoForAndroid/DemoForAndroid.csproj
+++ b/DemoForAndroid/DemoForAndroid.csproj
@@ -19,7 +19,7 @@
     <AndroidSupportedAbis>armeabi-v7a%3bx86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions>.m4a</AndroidStoreUncompressedFileExtensions>
     <MandroidI18n />
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <MonoGamePlatform>Android</MonoGamePlatform>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>

--- a/Widgets/Animation/VarmintAnimation.cs
+++ b/Widgets/Animation/VarmintAnimation.cs
@@ -12,7 +12,7 @@ namespace MonoVarmint.Widgets
     //--------------------------------------------------------------------------------------
     public class VarmintAnimation
     {
-        private readonly double? _animationDurationSeconds;
+        private readonly double _animationDurationSeconds;
         private TimeSpan? _animationStartTime;
 
         /// <summary>
@@ -35,19 +35,9 @@ namespace MonoVarmint.Widgets
 
         //--------------------------------------------------------------------------------------
         /// <summary>
-        /// Instantiates a new instance of the VarmintAnimation class with infinite duration
-        /// </summary>
-        //--------------------------------------------------------------------------------------
-        public VarmintAnimation()
-        {
-            _animationDurationSeconds = null;
-        }
-
-        //--------------------------------------------------------------------------------------
-        /// <summary>
         /// Instantiates a new instance of the VarmintAnimation class with the given duration
         /// </summary>
-        /// <param name="durationSeconds">The number of seconds the animation will last</param>
+        /// <param name="durationSeconds">The number of seconds the animation will last, with 0 meaning an infinite duration</param>
         //--------------------------------------------------------------------------------------
         public VarmintAnimation(double durationSeconds)
         {
@@ -83,9 +73,9 @@ namespace MonoVarmint.Widgets
             if (IsComplete) return;
             if (_animationStartTime == null) _animationStartTime = gameTime.TotalGameTime;
             var animationProgressSeconds = (gameTime.TotalGameTime - _animationStartTime.Value).TotalSeconds;
-            if (_animationDurationSeconds != null)
+            if (_animationDurationSeconds > 0)
             {
-                Animate(animationProgressSeconds / _animationDurationSeconds.Value);
+                Animate(animationProgressSeconds / _animationDurationSeconds);
                 if (animationProgressSeconds >= _animationDurationSeconds)
                 {
                     OnComplete?.Invoke();
@@ -105,7 +95,7 @@ namespace MonoVarmint.Widgets
         //--------------------------------------------------------------------------------------
         internal void Finish(VarmintWidget widget)
         {
-            if (_animationDurationSeconds != null) Update(new GameTime(TimeSpan.MaxValue, TimeSpan.MaxValue));
+            if (_animationDurationSeconds > 0) Update(new GameTime(TimeSpan.MaxValue, TimeSpan.MaxValue));
             else
             {
                 OnComplete?.Invoke();

--- a/Widgets/Animation/VarmintAnimation.cs
+++ b/Widgets/Animation/VarmintAnimation.cs
@@ -16,7 +16,6 @@ namespace MonoVarmint.Widgets
         private double _animationProgressSeconds;
         protected Action<double> Animate;
         
-
         /// <summary>
         /// IsComplete
         /// </summary>
@@ -78,7 +77,6 @@ namespace MonoVarmint.Widgets
                     _animationProgressSeconds = _animationDurationSeconds;
                     OnComplete?.Invoke();
                     IsComplete = true;
-                    return;
                 }
                 delta = _animationProgressSeconds / _animationDurationSeconds;
             }

--- a/Widgets/Animation/VarmintAnimation.cs
+++ b/Widgets/Animation/VarmintAnimation.cs
@@ -75,7 +75,7 @@ namespace MonoVarmint.Widgets
             var animationProgressSeconds = (gameTime.TotalGameTime - _animationStartTime.Value).TotalSeconds;
             if (_animationDurationSeconds > 0)
             {
-                Animate(animationProgressSeconds / _animationDurationSeconds);
+                Animate(Math.Min(Math.Max(0, animationProgressSeconds / _animationDurationSeconds), 1));
                 if (animationProgressSeconds >= _animationDurationSeconds)
                 {
                     OnComplete?.Invoke();

--- a/Widgets/WidgetBase/VarmintWidgetAnimationHandling.cs
+++ b/Widgets/WidgetBase/VarmintWidgetAnimationHandling.cs
@@ -8,7 +8,7 @@ using System.Xml;
 
 namespace MonoVarmint.Widgets
 {
-     public partial class VarmintWidget
+    public partial class VarmintWidget
     {
         //--------------------------------------------------------------------------------------
         /// <summary>


### PR DESCRIPTION
This change ensures that the `Animate` delegate is called with `delta` set to `1`, thus allowing the animation to take on its final value without needing to set it redundantly in the `OnComplete` handler.